### PR TITLE
remove temporary debug logging for dr

### DIFF
--- a/Utilities_Container.js
+++ b/Utilities_Container.js
@@ -11,7 +11,8 @@ var DR_USERS =
 	"nicolas.nicasio"
 ]
 
-
+//boolean to determine whether to use the CustomizationDR drive for testing.
+var spoofDRUser = false;
 
 
 //Network Storage. Production version
@@ -32,7 +33,7 @@ var DR_USERS =
 		var homeFolderPath = "/Volumes/Macintosh HD/Users/" + user;
 		var homeFolder = new Folder(homeFolderPath);
 
-		if(DR_USERS.indexOf(user)>-1)
+		if(DR_USERS.indexOf(user)>-1 || (spoofDRUser && user === "will.dowling"))
 		{
 			var customizationPath = "/Volumes/CustomizationDR/";
 		}


### PR DESCRIPTION
i had added lots of stuff to figure out why the build prod script was failing for the DR artists. The issue has been resolved, and the temp logging stuff was dirty. so i'm removing that so that the logging method can be rebuilt fresh.